### PR TITLE
 fix: deploy 단계에 checkout 설정

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,5 +40,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
       - name: Deploy to GitHub Pages
         run: npm run deploy


### PR DESCRIPTION
 job과 deploy는 환경이 달라 deploy에서 npm을 사용하기 위해 checkout 설정